### PR TITLE
feat: 초대 api 구현

### DIFF
--- a/src/main/java/com/example/memorip/controller/InvitationController.java
+++ b/src/main/java/com/example/memorip/controller/InvitationController.java
@@ -1,0 +1,52 @@
+package com.example.memorip.controller;
+
+
+import com.example.memorip.dto.InvitationDTO;
+import com.example.memorip.dto.InvitationRequest;
+import com.example.memorip.entity.Invitation;
+import com.example.memorip.exception.DefaultRes;
+import com.example.memorip.repository.InvitationMapper;
+import com.example.memorip.service.InvitationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "invitation", description = "초대링크 api 입니다.")
+@Slf4j
+@RestController
+@RequestMapping("/api/invitations")
+@Validated
+public class InvitationController {
+    private final InvitationService invitationService;
+
+    public InvitationController(InvitationService invitationService) {
+        this.invitationService = invitationService;
+    }
+
+    @Operation(summary = "초대링크 조회", description = "초대링크에 맞는 정보(plan)를 조회합니다.")
+    @GetMapping("/{slug}")
+    public ResponseEntity<DefaultRes<InvitationDTO>> getInvitation(@PathVariable String slug){
+        Invitation invitation = invitationService.findOneBySlug(slug);
+        InvitationDTO invitationDTO = InvitationMapper.INSTANCE.invitationToInvitationDTO(invitation);
+
+        return new ResponseEntity<>(DefaultRes.res(200, "초대링크 조회 성공", invitationDTO), HttpStatus.OK);
+    }
+
+    @Operation(summary = "초대링크 생성", description = "랜덤한 문자열로 초대링크를 생성합니다.")
+    @PostMapping("")
+    public ResponseEntity<DefaultRes<InvitationDTO>> createInvitation(
+            @Valid @RequestBody InvitationRequest request
+    ) {
+        Invitation invitation = invitationService.createOrUpdate(request.getPlanId());
+        InvitationDTO invitationDTO = InvitationMapper.INSTANCE.invitationToInvitationDTO(invitation);
+
+        return new ResponseEntity<>(DefaultRes.res(201, "초대링크 생성 성공", invitationDTO), HttpStatus.OK);
+    }
+
+
+}

--- a/src/main/java/com/example/memorip/dto/InvitationDTO.java
+++ b/src/main/java/com/example/memorip/dto/InvitationDTO.java
@@ -1,0 +1,16 @@
+package com.example.memorip.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class InvitationDTO {
+   private int id;
+   private int planId;
+   private String slug;
+   private LocalDateTime createdAt;
+   private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/memorip/dto/InvitationRequest.java
+++ b/src/main/java/com/example/memorip/dto/InvitationRequest.java
@@ -1,0 +1,12 @@
+package com.example.memorip.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+public class InvitationRequest {
+
+    @NotNull
+    int planId;
+}

--- a/src/main/java/com/example/memorip/entity/Invitation.java
+++ b/src/main/java/com/example/memorip/entity/Invitation.java
@@ -1,0 +1,35 @@
+package com.example.memorip.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "invitations")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Invitation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(nullable = false, unique = true)
+    private String slug;
+
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/memorip/exception/ErrorCode.java
+++ b/src/main/java/com/example/memorip/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     TIMELINE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 타임라인 정보를 찾을 수 없습니다"),
     TRAVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 여행기 정보를 찾을 수 없습니다"),
     USER_TRAVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 여행기를 작성할 수 있는 사용자가 아닙니다."),
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 초대 링크를 찾을 수 없습니다"),
+    INVITATION_EXPIRED(HttpStatus.NOT_FOUND, "초대 링크가 만료되었습니다"),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "데이터가 이미 존재합니다"),

--- a/src/main/java/com/example/memorip/repository/InvitationMapper.java
+++ b/src/main/java/com/example/memorip/repository/InvitationMapper.java
@@ -1,0 +1,13 @@
+package com.example.memorip.repository;
+
+import com.example.memorip.dto.InvitationDTO;
+import com.example.memorip.entity.Invitation;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface InvitationMapper{
+    InvitationMapper INSTANCE = Mappers.getMapper(InvitationMapper.class);
+
+    InvitationDTO invitationToInvitationDTO(Invitation invitation);
+}

--- a/src/main/java/com/example/memorip/repository/InvitationRepository.java
+++ b/src/main/java/com/example/memorip/repository/InvitationRepository.java
@@ -1,0 +1,15 @@
+package com.example.memorip.repository;
+
+import com.example.memorip.entity.Invitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Integer> {
+    @Query("SELECT i FROM Invitation i WHERE i.slug = :slug")
+    Optional<Invitation> findOneBySlug(String slug);
+
+    @Query("SELECT i FROM Invitation i WHERE i.plan.id = :planId")
+    Optional<Invitation> findOneByPlanId(Integer planId);
+}

--- a/src/main/java/com/example/memorip/service/InvitationService.java
+++ b/src/main/java/com/example/memorip/service/InvitationService.java
@@ -1,0 +1,74 @@
+package com.example.memorip.service;
+
+import com.example.memorip.entity.Invitation;
+import com.example.memorip.entity.Plan;
+import com.example.memorip.exception.CustomException;
+import com.example.memorip.exception.ErrorCode;
+import com.example.memorip.repository.InvitationRepository;
+import com.example.memorip.repository.PlanRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Random;
+
+@Service
+public class InvitationService {
+
+    private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int LENGTH = 8;
+
+    private final InvitationRepository invitationRepository;
+    private final PlanRepository planRepository;
+
+    public InvitationService(InvitationRepository invitationRepository, PlanRepository planRepository){
+        this.invitationRepository = invitationRepository;
+        this.planRepository = planRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Invitation findOneBySlug(String slug){
+        Invitation invitation = invitationRepository.findOneBySlug(slug).orElseThrow(()->new CustomException(ErrorCode.INVITATION_NOT_FOUND));
+        LocalDateTime updatedAt = invitation.getUpdatedAt();
+
+        if(updatedAt.isBefore(LocalDateTime.now().minusDays(1))){
+            throw new CustomException(ErrorCode.INVITATION_EXPIRED);
+        }
+        return invitation;
+    }
+
+    @Transactional
+    public Invitation createOrUpdate(Integer planId){
+        Plan plan = planRepository.findById(planId).orElseThrow(()->
+                new CustomException(ErrorCode.PLAN_NOT_FOUND));
+
+        Optional<Invitation> invitation = invitationRepository.findOneByPlanId(planId);
+
+        String slug = generateRandomString();
+        Invitation newInvitation = invitation.orElseGet(() -> {
+            Invitation invitation1 = new Invitation();
+            invitation1.setCreatedAt(LocalDateTime.now());
+            return invitation1;
+        });
+
+        newInvitation.setPlan(plan);
+        newInvitation.setSlug(slug);
+        newInvitation.setUpdatedAt(LocalDateTime.now());
+
+        return invitationRepository.save(newInvitation);
+    }
+
+    public static String generateRandomString(){
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder(LENGTH);
+
+        for(int i=0;i<LENGTH;i++){
+            int randomIndex = random.nextInt(CHARACTERS.length());
+            char randomChar = CHARACTERS.charAt(randomIndex);
+            sb.append(randomChar);
+        }
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Why need this change?
- 초대 API 구현
  - get `invitation/:slug` → 유효기간(1일) 안지났는지도 알려줌
  - post `invitation` → 이전에 생성한적없으면 create, 유효기간 지났다면 slug update

## Key Changes
-

## To Reviewers
- @eunnj 

## ScreenShot
-

## Reference
-